### PR TITLE
fix(Question): remove unused badge color map

### DIFF
--- a/src/components/Question/Question.jsx
+++ b/src/components/Question/Question.jsx
@@ -1,7 +1,6 @@
 import styles from "./Question.module.css";
 
 const Question = ({ text, tag }) => {
-  const bageColor = { easy: "green", medium: "yellow", hard: "red" };
   return (
     <div className={styles.question_wrapper}>
       <p className={styles.question_text}>{text}</p>


### PR DESCRIPTION
Remove the `bageColor` constant from Question.jsx. The map
served no purpose after refactoring and generated a linting warning,
so it is removed to clean up the component and keep the codebase
warning-free.